### PR TITLE
Adding public getters for IDs of annotations

### DIFF
--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/Annotation.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/Annotation.java
@@ -1,0 +1,9 @@
+package eu.clarin.weblicht.wlfxb.tc.api;
+
+/**
+ * Annotation interface is for elements that go in different annotation layers
+ * Created by krim on 3/13/17.
+ */
+public interface Annotation {
+    public String getId();
+}

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/Constituent.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/Constituent.java
@@ -27,7 +27,7 @@ package eu.clarin.weblicht.wlfxb.tc.api;
  * @author Yana Panchenko
  *
  */
-public interface Constituent {
+public interface Constituent extends Annotation {
 
     public boolean isTerminal();
 

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/ConstituentParse.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/ConstituentParse.java
@@ -27,7 +27,7 @@ package eu.clarin.weblicht.wlfxb.tc.api;
  * @author Yana Panchenko
  *
  */
-public interface ConstituentParse {
+public interface ConstituentParse extends Annotation {
 
     public Constituent getRoot();
 }

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/DependencyParse.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/DependencyParse.java
@@ -27,7 +27,7 @@ package eu.clarin.weblicht.wlfxb.tc.api;
  * @author Yana Panchenko
  *
  */
-public interface DependencyParse {
+public interface DependencyParse extends Annotation {
 
     public Dependency[] getDependencies();
 }

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/DiscourseConnective.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/DiscourseConnective.java
@@ -27,7 +27,7 @@ package eu.clarin.weblicht.wlfxb.tc.api;
  * @author Yana Panchenko
  *
  */
-public interface DiscourseConnective {
+public interface DiscourseConnective extends Annotation {
 
     public String getType();
 }

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/GeoPoint.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/GeoPoint.java
@@ -27,7 +27,7 @@ package eu.clarin.weblicht.wlfxb.tc.api;
  * @author Yana Panchenko
  *
  */
-public interface GeoPoint {
+public interface GeoPoint extends Annotation {
 
     public String getLongitude();
 

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/Lemma.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/Lemma.java
@@ -20,7 +20,7 @@
  */
 package eu.clarin.weblicht.wlfxb.tc.api;
 
-public interface Lemma {
+public interface Lemma extends Annotation {
 
     public String getString();
 }

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/NamedEntity.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/NamedEntity.java
@@ -27,7 +27,7 @@ package eu.clarin.weblicht.wlfxb.tc.api;
  * @author Yana Panchenko
  *
  */
-public interface NamedEntity {
+public interface NamedEntity extends Annotation {
 
     public String getType();
 }

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/Orthform.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/Orthform.java
@@ -27,7 +27,7 @@ package eu.clarin.weblicht.wlfxb.tc.api;
  * @author Yana Panchenko
  *
  */
-public interface Orthform {
+public interface Orthform extends Annotation {
 
     public String[] getValue();
 }

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/PosTag.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/PosTag.java
@@ -20,7 +20,7 @@
  */
 package eu.clarin.weblicht.wlfxb.tc.api;
 
-public interface PosTag {
+public interface PosTag extends Annotation {
 
     public String getString();
 }

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/Reference.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/Reference.java
@@ -27,7 +27,7 @@ package eu.clarin.weblicht.wlfxb.tc.api;
  * @author Yana Panchenko
  *
  */
-public interface Reference {
+public interface Reference extends Annotation {
 
     public String getType();
 

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/ReferencedEntity.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/ReferencedEntity.java
@@ -27,7 +27,7 @@ package eu.clarin.weblicht.wlfxb.tc.api;
  * @author Yana Panchenko
  *
  */
-public interface ReferencedEntity {
+public interface ReferencedEntity extends Annotation {
 
     public String getExternalId();
 

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/Sentence.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/Sentence.java
@@ -20,7 +20,7 @@
  */
 package eu.clarin.weblicht.wlfxb.tc.api;
 
-public interface Sentence {
+public interface Sentence extends Annotation {
 
     //public List<Token> getTokens();
     public Integer getStartCharOffset();

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/Token.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/Token.java
@@ -20,11 +20,9 @@
  */
 package eu.clarin.weblicht.wlfxb.tc.api;
 
-public interface Token {
+public interface Token extends Annotation {
 
     public String getString();
-
-    public String getID();
 
     public int getOrder();
 

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/ConstituentParseStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/ConstituentParseStored.java
@@ -44,6 +44,11 @@ public class ConstituentParseStored implements ConstituentParse {
     protected ConstituentStored constituentParseRoot;
 
     @Override
+    public String getId() {
+        return constituentParseId;
+    }
+
+    @Override
     public Constituent getRoot() {
         return constituentParseRoot;
     }

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/ConstituentStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/ConstituentStored.java
@@ -56,6 +56,11 @@ public class ConstituentStored implements Constituent {
     protected List<ConstituentStored> children = new ArrayList<ConstituentStored>();
 
     @Override
+    public String getId() {
+        return constituentId;
+    }
+
+    @Override
     public boolean isTerminal() {
         return children.isEmpty();
     }

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/DependencyParseStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/DependencyParseStored.java
@@ -48,6 +48,11 @@ public class DependencyParseStored implements DependencyParse {
     protected List<EmptyTokenStored> emptytoks;
 
     @Override
+    public String getId() {
+        return parseId;
+    }
+
+    @Override
     public Dependency[] getDependencies() {
         if (dependencies == null) {
             return new Dependency[0];

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/DiscourseConnectiveStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/DiscourseConnectiveStored.java
@@ -45,8 +45,15 @@ public class DiscourseConnectiveStored implements DiscourseConnective {
 	protected String type;
 	@XmlAttribute(name=CommonAttributes.TOKEN_SEQUENCE_REFERENCE, required = true)
 	protected String[] tokRefs;
-	
-	
+
+	/**
+	 * DiscourceConnectives do not have any identifier, always return null
+	 */
+	@Override
+	public String getId() {
+		return null;
+	}
+
 
 	@Override
 	public String getType() {

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/EmptyTokenStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/EmptyTokenStored.java
@@ -46,8 +46,13 @@ public class EmptyTokenStored implements Token {
 	@XmlAttribute(name=CommonAttributes.ID, required = true)
 	protected String id;
 	protected int order;
-	
-	
+
+	@Override
+	public String getId() {
+		return id;
+	}
+
+
 	@Override
 	public String getString() {
             return tokenString;

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/GeoPointStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/GeoPointStored.java
@@ -58,6 +58,11 @@ public class GeoPointStored implements GeoPoint {
     protected String[] tokRefs;
 
     @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
     public String getLongitude() {
         return longitude;
     }

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/LemmaStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/LemmaStored.java
@@ -46,6 +46,11 @@ public class LemmaStored implements Lemma {
     protected String[] tokRefs;
 
     @Override
+    public String getId() {
+        return lemmaId;
+    }
+
+    @Override
     public String getString() {
         return lemmaString;
     }

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/NamedEntityStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/NamedEntityStored.java
@@ -48,6 +48,11 @@ public class NamedEntityStored implements NamedEntity {
     protected String[] tokRefs;
 
     @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
     public String getType() {
         return type;
     }

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/OrthformStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/OrthformStored.java
@@ -47,6 +47,11 @@ public class OrthformStored implements Orthform {
     protected String[] lemmaRefs;
 
     @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
     public String[] getValue() {
         String[] splittedValues = values.split(",[ ]*");
         return splittedValues;

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/PosTagStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/PosTagStored.java
@@ -46,6 +46,11 @@ public class PosTagStored implements PosTag {
     protected String[] tokRefs;
 
     @Override
+    public String getId() {
+        return tagId;
+    }
+
+    @Override
     public String getString() {
         return tagString;
     }

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/ReferenceStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/ReferenceStored.java
@@ -56,6 +56,11 @@ public class ReferenceStored implements Reference {
     protected String[] minTokRefs;
 
     @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
     public String getType() {
         return type;
     }

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/ReferencedEntityStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/ReferencedEntityStored.java
@@ -47,6 +47,11 @@ public class ReferencedEntityStored implements ReferencedEntity {
     protected List<ReferenceStored> references = new ArrayList<ReferenceStored>();
 
     @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         if (id != null) {

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/SentenceStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/SentenceStored.java
@@ -48,6 +48,11 @@ public class SentenceStored implements Sentence {
     protected Integer end;
 
     @Override
+    public String getId() {
+        return sentenceId;
+    }
+
+    @Override
     public Integer getStartCharOffset() {
         return start;
     }

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/TokenStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/TokenStored.java
@@ -55,7 +55,7 @@ public class TokenStored implements Token {
     }
 
     @Override
-    public String getID() {
+    public String getId() {
         return tokenId;
     }
 


### PR DESCRIPTION
A new interface `Annotation` is introduced as an abstraction for all annotation classes. I tried to find as many first-order annotation objects as possible based on [weblicht/tcf-spec](https://github.com/weblicht/tcf-spec/blob/master/src/main/rnc-schema/textcorpus_0_4.rnc) and modified them to implements `Annotation` interface, **BUT** I might have missed some because of my lack of familiarity to the TCF world. Please review the changes and add more if necessary, in case you merge this. So @elahi123 , please go ahead and review this request. These are the classes I edited. 

* `Constituent` -> `ConstituentStored`
* `ConstituentParse` -> `ConstituentParseStored`
* `DependencyParse` -> `DependencyParseStored`
* `DiscourseConnective` -> `DiscourseConnectiveStored`
* `GeoPoint` -> `GeoPointStored`
* `Lemma` -> `LemmaStored`
* `NamedEntity` -> `NamedEntityStored`
* `Orthform` -> `OrthformStored`
* `PosTag` -> `PosTagStored`
* `Reference` -> `ReferenceStored`
* `ReferencedEntity` -> `ReferencedEntityStored`
* `Sentence` -> `SentenceStored`
* `Token` -> `EmptyTokenStored` (`TokenStored` already has `getId()`)

@ksuderman could you take a look at the list to see if I'm missing any annotation object that should mapped into LIF?
