### PR TITLE
Adding support for the new topological field layer (TCF5)

### DIFF
--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/TextCorpus.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/TextCorpus.java
@@ -147,7 +147,7 @@ public interface TextCorpus {
     /**
      * Gets sentences layer of this <tt>TextCorpus</tt>.
      *
-     * layer containing sentence boundary annotations on {@link Token}
+     * @return layer containing sentence boundary annotations on {@link Token}
      * objects from {@link TokensLayer}.
      */
     public SentencesLayer getSentencesLayer();

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/TextCorpus.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/TextCorpus.java
@@ -118,7 +118,6 @@ public interface TextCorpus {
      */
     public PosTagsLayer getPosTagsLayer();
 
-
     /**
      * Creates empty {@link PosTagsLayer} with the given tagset in this
      * <tt>TextCorpus</tt>.
@@ -129,11 +128,10 @@ public interface TextCorpus {
     public PosTagsLayer createPosTagsLayer(String tagset);
 
     /**
-     * Creates empty {@link PosTagsLayer} with the given tagset in this
-     * <tt>TextCorpus</tt>.
+     * Gets topological fields layer of this <tt>TextCorpus</tt>.
      *
-     * @param tagset of the part-of-speech annotations.
-     * @return annotation layer that has been created.
+     * @return layer containing topological field annotations on {@link Token}
+     * objects from {@link TokensLayer}.
      */
     public TopologicalFieldsLayer getTopologicalFieldsLayer();
 
@@ -141,20 +139,17 @@ public interface TextCorpus {
      * Creates empty {@link TopologicalFieldsLayer} with the given tagset in this
      * <tt>TextCorpus</tt>.
      *
-     * @param tagset of the part-of-speech annotations.
+     * @param tagset of the topological fields.
      * @return annotation layer that has been created.
      */
-    
     public TopologicalFieldsLayer createTopologicalFieldsLayer(String tagset);
 
     /**
-     * Creates empty {@link TopologicalFieldsLayer} with the given tagset in this
-     * <tt>TextCorpus</tt>.
+     * Gets sentences layer of this <tt>TextCorpus</tt>.
      *
-     * @param tagset of the topological field annotations.
-     * @return annotation layer that has been created.
+     * layer containing sentence boundary annotations on {@link Token}
+     * objects from {@link TokensLayer}.
      */
-
     public SentencesLayer getSentencesLayer();
 
     /**

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/TextCorpus.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/TextCorpus.java
@@ -118,6 +118,7 @@ public interface TextCorpus {
      */
     public PosTagsLayer getPosTagsLayer();
 
+
     /**
      * Creates empty {@link PosTagsLayer} with the given tagset in this
      * <tt>TextCorpus</tt>.
@@ -128,11 +129,32 @@ public interface TextCorpus {
     public PosTagsLayer createPosTagsLayer(String tagset);
 
     /**
-     * Gets sentences layer of this <tt>TextCorpus</tt>.
+     * Creates empty {@link PosTagsLayer} with the given tagset in this
+     * <tt>TextCorpus</tt>.
      *
-     * @return layer containing sentence boundary annotations on {@link Token}
-     * objects from {@link TokensLayer}.
+     * @param tagset of the part-of-speech annotations.
+     * @return annotation layer that has been created.
      */
+    public TopologicalFieldsLayer getTopologicalFieldsLayer();
+
+    /**
+     * Creates empty {@link TopologicalFieldsLayer} with the given tagset in this
+     * <tt>TextCorpus</tt>.
+     *
+     * @param tagset of the part-of-speech annotations.
+     * @return annotation layer that has been created.
+     */
+    
+    public TopologicalFieldsLayer createTopologicalFieldsLayer(String tagset);
+
+    /**
+     * Creates empty {@link TopologicalFieldsLayer} with the given tagset in this
+     * <tt>TextCorpus</tt>.
+     *
+     * @param tagset of the topological field annotations.
+     * @return annotation layer that has been created.
+     */
+
     public SentencesLayer getSentencesLayer();
 
     /**

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/TopologicalField.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/TopologicalField.java
@@ -1,0 +1,26 @@
+/**
+ * wlfxb - a library for creating and processing of TCF data streams.
+ *
+ * Copyright (C) University of Tübingen.
+ *
+ * This file is part of wlfxb.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.clarin.weblicht.wlfxb.tc.api;
+
+public interface TopologicalField extends ExtraAttributes{
+
+    public String getString();
+}

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/TopologicalFieldsLayer.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/api/TopologicalFieldsLayer.java
@@ -1,0 +1,46 @@
+/**
+ * wlfxb - a library for creating and processing of TCF data streams.
+ *
+ * Copyright (C) University of Tübingen.
+ *
+ * This file is part of wlfxb.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.clarin.weblicht.wlfxb.tc.api;
+
+import java.util.List;
+
+/**
+ * The <tt>TopologicalFieldLayer</tt> layer annotates tokens with topological field tags. 
+ * Each tag element references a token, or sequence of tokens, and provides the 
+ * tag string value. Tag values usually belong to some predefined standard tagset.
+ * The layer specifies the name of the tagset via the tagset attribute.
+ * 
+ * @author Neele Witte
+ */
+public interface TopologicalFieldsLayer extends TextCorpusLayer {
+
+    public String getTagset();
+
+    public TopologicalField getTag(int index);
+
+    public TopologicalField getTag(Token token);
+
+    public Token[] getTokens(TopologicalField tag);
+
+    public TopologicalField addTag(String tagString, Token tagToken);
+
+    public TopologicalField addTag(String tagString, List<Token> tagTokens);
+}

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/TextCorpusLayerTag.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/TextCorpusLayerTag.java
@@ -40,6 +40,7 @@ public enum TextCorpusLayerTag {
     SENTENCES(SentencesLayerStored.XML_NAME, SentencesLayerStored.class),
     LEMMAS(LemmasLayerStored.XML_NAME, LemmasLayerStored.class),
     POSTAGS(PosTagsLayerStored.XML_NAME, PosTagsLayerStored.class),
+    TOPOLOGICAL_FIELDS(TopologicalFieldsLayerStored.XML_NAME, TopologicalFieldsLayerStored.class),
     MORPHOLOGY(MorphologyLayerStored.XML_NAME, MorphologyLayerStored.class),
     PARSING_CONSTITUENT(ConstituentParsingLayerStored.XML_NAME, ConstituentParsingLayerStored.class),
     PARSING_DEPENDENCY(DependencyParsingLayerStored.XML_NAME, DependencyParsingLayerStored.class),
@@ -98,6 +99,7 @@ public enum TextCorpusLayerTag {
         layerDependencies.put(TextCorpusLayerTag.TOKENS, EnumSet.noneOf(TextCorpusLayerTag.class));
         layerDependencies.put(TextCorpusLayerTag.LEMMAS, EnumSet.of(TextCorpusLayerTag.TOKENS));
         layerDependencies.put(TextCorpusLayerTag.POSTAGS, EnumSet.of(TextCorpusLayerTag.TOKENS));
+        layerDependencies.put(TextCorpusLayerTag.TOPOLOGICAL_FIELDS, EnumSet.of(TextCorpusLayerTag.TOKENS));
         layerDependencies.put(TextCorpusLayerTag.SENTENCES, EnumSet.of(TextCorpusLayerTag.TOKENS));
         layerDependencies.put(TextCorpusLayerTag.NAMED_ENTITIES, EnumSet.of(TextCorpusLayerTag.TOKENS));
         layerDependencies.put(TextCorpusLayerTag.CHUNKS, EnumSet.of(TextCorpusLayerTag.TOKENS));

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/TextCorpusLayersConnector.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/TextCorpusLayersConnector.java
@@ -21,7 +21,7 @@
 package eu.clarin.weblicht.wlfxb.tc.xb;
 
 import eu.clarin.weblicht.wlfxb.tc.api.*;
-
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/TextCorpusLayersConnector.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/TextCorpusLayersConnector.java
@@ -21,7 +21,7 @@
 package eu.clarin.weblicht.wlfxb.tc.xb;
 
 import eu.clarin.weblicht.wlfxb.tc.api.*;
-import java.util.EnumMap;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +35,7 @@ public class TextCorpusLayersConnector {
     protected Map<String, Lemma> lemmaId2ItsLemma = new HashMap<String, Lemma>();
     protected Map<Token, Lemma> token2ItsLemma = new HashMap<Token, Lemma>();
     protected Map<Token, PosTag> token2ItsPosTag = new HashMap<Token, PosTag>();
+    protected Map<Token, TopologicalField> token2ItsTopoField = new HashMap<>();
     protected Map<Token, Sentence> token2ItsSentence = new HashMap<Token, Sentence>();
     protected Map<Token, MorphologyAnalysis> token2ItsAnalysis = new HashMap<Token, MorphologyAnalysis>();
     //Map<Token,NamedEntity> token2ItsNE = new HashMap<Token,NamedEntity>();

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/TextCorpusStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/TextCorpusStored.java
@@ -45,6 +45,7 @@ import javax.xml.bind.annotation.*;
     "sentencesLayer",
     "lemmasLayer",
     "posTagsLayer",
+    "topologicalFieldsLayer",
     "constituentParsingLayer",
     "dependencyParsingLayer",
     "morphologyLayer",
@@ -124,6 +125,11 @@ public class TextCorpusStored implements TextCorpus {
     @Override
     public PosTagsLayer createPosTagsLayer(String tagset) {
         return initializeLayer(PosTagsLayerStored.class, tagset);
+    }
+
+    @Override
+    public TopologicalFieldsLayer createTopologicalFieldsLayer (String tagset) { 
+    	return initializeLayer(TopologicalFieldsLayerStored.class, tagset); 
     }
 
     @Override
@@ -400,6 +406,16 @@ public class TextCorpusStored implements TextCorpus {
     @Override
     public PosTagsLayerStored getPosTagsLayer() {
         return ((PosTagsLayerStored) layersInOrder[TextCorpusLayerTag.POSTAGS.ordinal()]);
+    }
+    
+    @XmlElement(name = TopologicalFieldsLayerStored.XML_NAME)
+    protected void setTopologicalFieldsLayer(TopologicalFieldsLayerStored layer) {
+        layersInOrder[TextCorpusLayerTag.TOPOLOGICAL_FIELDS.ordinal()] = layer;
+    }
+
+    @Override
+    public TopologicalFieldsLayerStored getTopologicalFieldsLayer() {
+        return ((TopologicalFieldsLayerStored) layersInOrder[TextCorpusLayerTag.TOPOLOGICAL_FIELDS.ordinal()]);
     }
 
     @XmlElement(name = ConstituentParsingLayerStored.XML_NAME)

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/TopologicalFieldStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/TopologicalFieldStored.java
@@ -1,0 +1,74 @@
+/**
+ * wlfxb - a library for creating and processing of TCF data streams.
+ *
+ * Copyright (C) University of Tübingen.
+ *
+ * This file is part of wlfxb.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ *
+ */
+package eu.clarin.weblicht.wlfxb.tc.xb;
+
+
+import eu.clarin.weblicht.wlfxb.tc.api.TopologicalField;
+import eu.clarin.weblicht.wlfxb.utils.CommonAttributes;
+
+import javax.xml.bind.annotation.*;
+import javax.xml.namespace.QName;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+
+/**
+ * @author Neele Witte
+ *
+ */
+@XmlRootElement(name = TopologicalFieldStored.XML_NAME)
+@XmlAccessorType(XmlAccessType.NONE)
+public class TopologicalFieldStored implements TopologicalField {
+
+    public static final String XML_NAME = "field";
+    //public static final String ID_PREFIX = "p_";
+    @XmlValue
+    protected String tagString;
+    @XmlAttribute(name = CommonAttributes.ID)
+    protected String tagId;
+    @XmlAttribute(name = CommonAttributes.TOKEN_SEQUENCE_REFERENCE, required = true)
+    protected String[] tokRefs;
+    @XmlAnyAttribute
+    protected LinkedHashMap<QName, String> extraAttributes = new LinkedHashMap<QName, String>();
+  
+    @Override
+    public LinkedHashMap<String, String> getExtraAttributes() {
+        return TopologicalField.super.retrieveAttributes(extraAttributes);
+    }
+
+    @Override
+    public String getString() {
+        return tagString;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        if (tagId != null) {
+            sb.append(tagId);
+            sb.append(" -> ");
+        }
+        sb.append(this.tagString).append(" ").append(Arrays.toString(tokRefs));
+        return sb.toString();
+    }
+}

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/TopologicalFieldStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/TopologicalFieldStored.java
@@ -41,7 +41,6 @@ import java.util.LinkedHashMap;
 public class TopologicalFieldStored implements TopologicalField {
 
     public static final String XML_NAME = "field";
-    //public static final String ID_PREFIX = "p_";
     @XmlValue
     protected String tagString;
     @XmlAttribute(name = CommonAttributes.ID)

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/TopologicalFieldsLayerStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/TopologicalFieldsLayerStored.java
@@ -1,0 +1,138 @@
+/**
+ * wlfxb - a library for creating and processing of TCF data streams.
+ *
+ * Copyright (C) University of Tübingen.
+ *
+ * This file is part of wlfxb.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ *
+ */
+package eu.clarin.weblicht.wlfxb.tc.xb;
+
+import eu.clarin.weblicht.wlfxb.tc.api.Token;
+import eu.clarin.weblicht.wlfxb.tc.api.TopologicalField;
+import eu.clarin.weblicht.wlfxb.tc.api.TopologicalFieldsLayer;
+import eu.clarin.weblicht.wlfxb.utils.CommonAttributes;
+import eu.clarin.weblicht.wlfxb.utils.WlfUtilities;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.xml.bind.annotation.*;
+
+/**
+ * @author Neele Witte
+ *
+ */
+@XmlRootElement(name = TopologicalFieldsLayerStored.XML_NAME)
+@XmlAccessorType(XmlAccessType.NONE)
+public class TopologicalFieldsLayerStored extends TextCorpusLayerStoredAbstract implements TopologicalFieldsLayer {
+
+    public static final String XML_NAME = "topologicalFields";
+    @XmlAttribute(name = CommonAttributes.TAGSET, required = true)
+    private String tagset;
+    @XmlElement(name = TopologicalFieldStored.XML_NAME)
+    private List<TopologicalFieldStored> tags = new ArrayList<TopologicalFieldStored>();
+    private TextCorpusLayersConnector connector;
+
+    protected TopologicalFieldsLayerStored() {
+    }
+
+    protected TopologicalFieldsLayerStored(String tagset) {
+        this.tagset = tagset;
+    }
+
+    protected TopologicalFieldsLayerStored(TextCorpusLayersConnector connector) {
+        this.connector = connector;
+    }
+
+    protected void setLayersConnector(TextCorpusLayersConnector connector) {
+        this.connector = connector;
+        for (TopologicalFieldStored tag : tags) {
+            for (String tokRef : tag.tokRefs) {
+                connector.token2ItsTopoField.put(connector.tokenId2ItsToken.get(tokRef), tag);
+            }
+        }
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return tags.isEmpty();
+    }
+
+    @Override
+    public int size() {
+        return tags.size();
+    }
+
+    @Override
+    public String getTagset() {
+        return tagset;
+    }
+
+    @Override
+    public TopologicalField getTag(int index) {
+        TopologicalField tag = tags.get(index);
+        return tag;
+    }
+
+    @Override
+    public TopologicalField getTag(Token token) {
+        TopologicalField tag = connector.token2ItsTopoField.get(token);
+        return tag;
+    }
+
+    @Override
+    public Token[] getTokens(TopologicalField tag) {
+        if (tag instanceof PosTagStored) {
+            TopologicalFieldStored tagStored = (TopologicalFieldStored) tag;
+            return WlfUtilities.tokenIdsToTokens(tagStored.tokRefs, connector.tokenId2ItsToken);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public TopologicalField addTag(String tagString, Token tagToken) {
+        List<Token> tagTokens = Arrays.asList(new Token[]{tagToken});
+        return addTag(tagString, tagTokens);
+    }
+
+    @Override
+    public TopologicalField addTag(String tagString, List<Token> tagTokens) {
+        TopologicalFieldStored tag = new TopologicalFieldStored();
+        tag.tagString = tagString;
+        tag.tokRefs = new String[tagTokens.size()];
+        for (int i = 0; i < tagTokens.size(); i++) {
+            Token token = tagTokens.get(i);
+            tag.tokRefs[i] = token.getID();
+            connector.token2ItsTopoField.put(token, tag);
+        }
+        tags.add(tag);
+        return tag;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(XML_NAME);
+        sb.append(" ");
+        sb.append("{");
+        sb.append(tagset);
+        sb.append("} :");
+        sb.append(tags.toString());
+        return sb.toString();
+    }
+}

--- a/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/TopologicalFieldsLayerStored.java
+++ b/src/main/java/eu/clarin/weblicht/wlfxb/tc/xb/TopologicalFieldsLayerStored.java
@@ -97,7 +97,7 @@ public class TopologicalFieldsLayerStored extends TextCorpusLayerStoredAbstract 
 
     @Override
     public Token[] getTokens(TopologicalField tag) {
-        if (tag instanceof PosTagStored) {
+        if (tag instanceof TopologicalFieldStored) {
             TopologicalFieldStored tagStored = (TopologicalFieldStored) tag;
             return WlfUtilities.tokenIdsToTokens(tagStored.tokRefs, connector.tokenId2ItsToken);
         } else {

--- a/src/test/java/eu/clarin/weblicht/wlfxb/tc/test_v5/TextCorpusTopologicalFieldsTest.java
+++ b/src/test/java/eu/clarin/weblicht/wlfxb/tc/test_v5/TextCorpusTopologicalFieldsTest.java
@@ -4,8 +4,6 @@
 package eu.clarin.weblicht.wlfxb.tc.test_v5;
 
 import eu.clarin.weblicht.wlfxb.io.TextCorpusStreamed;
-import eu.clarin.weblicht.wlfxb.tc.api.ChunksLayer;
-import eu.clarin.weblicht.wlfxb.tc.api.PosTagsLayer;
 import eu.clarin.weblicht.wlfxb.tc.api.TextCorpus;
 import eu.clarin.weblicht.wlfxb.tc.api.Token;
 import eu.clarin.weblicht.wlfxb.tc.api.TopologicalFieldsLayer;
@@ -53,6 +51,11 @@ public class TextCorpusTopologicalFieldsTest extends AbstractTextCorpusTest {
     	token2Topo.put(".", "UNK");
     }
 
+    /**
+     * Checks if the new topological field layer can be read from TCF, if it has the expected size and if the first
+     * and the last topological field match the expected tag
+     * @throws Exception
+     */
     @Test
     public void testRead() throws Exception {
         TextCorpus tc = read(INPUT_FILE_WITH_LAYER, layersToReadAfterTopoTagging);
@@ -62,23 +65,24 @@ public class TextCorpusTopologicalFieldsTest extends AbstractTextCorpusTest {
         Assert.assertEquals(tc.getTokensLayer().getToken(0), layer.getTokens(layer.getTag(0))[0]);
     }
 
+    /**
+     * Checks if a TCF can be read and a the new topological field layer can be added. The layer specifies a tagset
+     * and adds a topological field for each token. Checks if the new XML file created with the library matches the
+     * expected XML file.
+     * @throws Exception
+     */
     @Test
     public void testReadWrite() throws Exception {
         String outfile = testFolder.getRoot() + File.separator + OUTPUT_FILE;
         TextCorpusStreamed tc = open(INPUT_FILE_WITHOUT_LAYER, outfile, layersToReadBeforeTopoTagging);
-        System.out.println(tc);
-        // create topological fields layer, it's empty at first
         TopologicalFieldsLayer tags = tc.createTopologicalFieldsLayer("DANIELDK");
         for (int i = 0; i < tc.getTokensLayer().size(); i++) {
             Token token = tc.getTokensLayer().getToken(i);
             String topoTag = tag(token.getString());
-            // create and add topological field to the tags layer
             tags.addTag(topoTag, token);
         }
         // IMPORTANT close the streams!!!
         tc.close();
-        System.out.println(tc);
-        // compare output xml with expected xml
         assertEqualXml(EXPECTED_OUTPUT_FILE, outfile);
     }
 

--- a/src/test/java/eu/clarin/weblicht/wlfxb/tc/test_v5/TextCorpusTopologicalFieldsTest.java
+++ b/src/test/java/eu/clarin/weblicht/wlfxb/tc/test_v5/TextCorpusTopologicalFieldsTest.java
@@ -1,0 +1,88 @@
+/**
+ *
+ */
+package eu.clarin.weblicht.wlfxb.tc.test_v5;
+
+import eu.clarin.weblicht.wlfxb.io.TextCorpusStreamed;
+import eu.clarin.weblicht.wlfxb.tc.api.ChunksLayer;
+import eu.clarin.weblicht.wlfxb.tc.api.PosTagsLayer;
+import eu.clarin.weblicht.wlfxb.tc.api.TextCorpus;
+import eu.clarin.weblicht.wlfxb.tc.api.Token;
+import eu.clarin.weblicht.wlfxb.tc.api.TopologicalFieldsLayer;
+import eu.clarin.weblicht.wlfxb.tc.test.AbstractTextCorpusTest;
+import eu.clarin.weblicht.wlfxb.tc.xb.TextCorpusLayerTag;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import java.io.File;
+
+/**
+ * @author Neele Witte
+ *
+ */
+public class TextCorpusTopologicalFieldsTest extends AbstractTextCorpusTest {
+
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+    private static final String INPUT_FILE_WITHOUT_LAYER = "/data_v5/tc-topo/tcf-before.xml";
+    private static final String INPUT_FILE_WITH_LAYER = "/data_v5/tc-topo/tcf-after.xml";
+    private static final String EXPECTED_OUTPUT_FILE = "/data_v5/tc-topo/output-expected.xml";
+    private static final String OUTPUT_FILE = "output.xml";
+
+    
+    private static final EnumSet<TextCorpusLayerTag> layersToReadBeforeTopoTagging =
+            EnumSet.of(TextCorpusLayerTag.TOKENS, TextCorpusLayerTag.POSTAGS);
+    private static final EnumSet<TextCorpusLayerTag> layersToReadAfterTopoTagging =
+            EnumSet.of(TextCorpusLayerTag.TOKENS, TextCorpusLayerTag.POSTAGS, TextCorpusLayerTag.TOPOLOGICAL_FIELDS);
+    public static final Map<String, String> token2Topo = new HashMap<String, String>();
+
+    static {
+    	token2Topo.put("Peter", "VF");
+    	token2Topo.put("aß", "LK");
+    	token2Topo.put("eine", "MF");
+    	token2Topo.put("Käsepizza", "MF");
+    	token2Topo.put(".", "UNK");
+    	token2Topo.put("Sie", "VF");
+    	token2Topo.put("schmeckte", "LK");
+    	token2Topo.put("ihm", "MF");
+    	token2Topo.put(".", "UNK");
+    }
+
+    @Test
+    public void testRead() throws Exception {
+        TextCorpus tc = read(INPUT_FILE_WITH_LAYER, layersToReadAfterTopoTagging);
+        TopologicalFieldsLayer layer = tc.getTopologicalFieldsLayer();
+        Assert.assertEquals(9, layer.size());
+        Assert.assertEquals("VF", layer.getTag(0).getString());
+        Assert.assertEquals(tc.getTokensLayer().getToken(0), layer.getTokens(layer.getTag(0))[0]);
+    }
+
+    @Test
+    public void testReadWrite() throws Exception {
+        String outfile = testFolder.getRoot() + File.separator + OUTPUT_FILE;
+        TextCorpusStreamed tc = open(INPUT_FILE_WITHOUT_LAYER, outfile, layersToReadBeforeTopoTagging);
+        System.out.println(tc);
+        // create topological fields layer, it's empty at first
+        TopologicalFieldsLayer tags = tc.createTopologicalFieldsLayer("DANIELDK");
+        for (int i = 0; i < tc.getTokensLayer().size(); i++) {
+            Token token = tc.getTokensLayer().getToken(i);
+            String topoTag = tag(token.getString());
+            // create and add topological field to the tags layer
+            tags.addTag(topoTag, token);
+        }
+        // IMPORTANT close the streams!!!
+        tc.close();
+        System.out.println(tc);
+        // compare output xml with expected xml
+        assertEqualXml(EXPECTED_OUTPUT_FILE, outfile);
+    }
+
+    private String tag(String tokenString) {
+        return token2Topo.get(tokenString);
+    }
+}

--- a/src/test/java/eu/clarin/weblicht/wlfxb/tclayers/test_v5/TopologicalFieldsTest.java
+++ b/src/test/java/eu/clarin/weblicht/wlfxb/tclayers/test_v5/TopologicalFieldsTest.java
@@ -1,0 +1,49 @@
+/**
+ *
+ */
+package eu.clarin.weblicht.wlfxb.tclayers.test;
+
+import eu.clarin.weblicht.wlfxb.tc.api.TopologicalFieldsLayer;
+import eu.clarin.weblicht.wlfxb.tc.xb.PosTagsLayerStored;
+import eu.clarin.weblicht.wlfxb.tc.xb.TopologicalFieldsLayerStored;
+import eu.clarin.weblicht.wlfxb.test.utils.TestUtils;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * @author Neele Witte
+ *
+ */
+public class TopologicalFieldsTest {
+
+    private static final String INPUT = "/data_v5/tc-topo/layer-input.xml";
+
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+    @Test
+    public void testReadAndWriteBack() throws Exception {
+
+        InputStream is = this.getClass().getResourceAsStream(INPUT);
+        OutputStream os = new FileOutputStream(testFolder.newFile("layer-output.xml"));
+
+
+        TopologicalFieldsLayer layer = TestUtils.read(TopologicalFieldsLayerStored.class, is);
+        System.out.println(layer);
+        TestUtils.write(layer, os);
+
+        is.close();
+        os.close();
+
+        Assert.assertEquals("DANIELDK", layer.getTagset());
+        Assert.assertEquals(9, layer.size());
+        Assert.assertEquals("VF", layer.getTag(0).getString());
+        Assert.assertEquals("UNK", layer.getTag(layer.size() - 1).getString());
+
+    }
+}

--- a/src/test/java/eu/clarin/weblicht/wlfxb/tclayers/test_v5/TopologicalFieldsTest.java
+++ b/src/test/java/eu/clarin/weblicht/wlfxb/tclayers/test_v5/TopologicalFieldsTest.java
@@ -4,7 +4,6 @@
 package eu.clarin.weblicht.wlfxb.tclayers.test;
 
 import eu.clarin.weblicht.wlfxb.tc.api.TopologicalFieldsLayer;
-import eu.clarin.weblicht.wlfxb.tc.xb.PosTagsLayerStored;
 import eu.clarin.weblicht.wlfxb.tc.xb.TopologicalFieldsLayerStored;
 import eu.clarin.weblicht.wlfxb.test.utils.TestUtils;
 import java.io.FileOutputStream;
@@ -34,12 +33,16 @@ public class TopologicalFieldsTest {
 
 
         TopologicalFieldsLayer layer = TestUtils.read(TopologicalFieldsLayerStored.class, is);
-        System.out.println(layer);
         TestUtils.write(layer, os);
 
         is.close();
         os.close();
 
+        /**
+         * Checks if the topolofical field tagset matches the expected tagset: DANEIKDK
+         * Checks if there are 9 topological fields that have been tagged
+         * Checks if the first topological field is VF (Vorfeld) and the last field is UNK (topo field for punctuation)
+         */
         Assert.assertEquals("DANIELDK", layer.getTagset());
         Assert.assertEquals(9, layer.size());
         Assert.assertEquals("VF", layer.getTag(0).getString());

--- a/src/test/resources/data_v5/tc-topo/layer-input.xml
+++ b/src/test/resources/data_v5/tc-topo/layer-input.xml
@@ -1,0 +1,11 @@
+<topologicalFields tagset="DANIELDK" xmlns="http://www.dspin.de/data/textcorpus">
+   <field tokenIDs="t1">VF</field>
+   <field tokenIDs="t2">LK</field>
+   <field tokenIDs="t3">MF</field>
+   <field tokenIDs="t4">MF</field>
+   <field tokenIDs="t5">UNK</field>
+   <field tokenIDs="t6">VF</field>
+   <field tokenIDs="t7">LK</field>
+   <field tokenIDs="t8">MF</field>
+   <field tokenIDs="t9">UNK</field>
+</topologicalFields>

--- a/src/test/resources/data_v5/tc-topo/output-expected.xml
+++ b/src/test/resources/data_v5/tc-topo/output-expected.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml-model href="http://de.clarin.eu/images/weblicht-tutorials/resources/tcf-04/schemas/latest/d-spin_0_4.rnc" type="application/relax-ng-compact-syntax"?>
+<D-Spin xmlns="http://www.dspin.de/data" version="0.4">
+  <MetaData xmlns="http://www.dspin.de/data/metadata">
+    <source>IMS, Uni Stuttgart</source>
+  </MetaData>
+  <TextCorpus xmlns="http://www.dspin.de/data/textcorpus" lang="de">
+    <text>Peter aß eine Käsepizza. Sie schmeckte ihm.</text>
+    <tokens><token ID="t1">Peter</token><token ID="t2">aß</token><token ID="t3">eine</token><token ID="t4">Käsepizza</token><token ID="t5">.</token><token ID="t6">Sie</token><token ID="t7">schmeckte</token><token ID="t8">ihm</token><token ID="t9">.</token></tokens>
+    <sentences>
+      <sentence ID="s1" tokenIDs="t1 t2 t3 t4 t5"></sentence>
+      <sentence ID="s2" tokenIDs="t6 t7 t8 t9"></sentence>
+    </sentences>
+    <lemmas>
+      <lemma ID="l1" tokenIDs="t1">Peter</lemma>
+      <lemma ID="l2" tokenIDs="t2">essen</lemma>
+      <lemma ID="l3" tokenIDs="t3">ein</lemma>
+      <lemma ID="l4" tokenIDs="t4">Käsepizza</lemma>
+      <lemma ID="l5" tokenIDs="t5">.</lemma>
+      <lemma ID="l6" tokenIDs="t6">sie</lemma>
+      <lemma ID="l7" tokenIDs="t7">schmecken</lemma>
+      <lemma ID="l8" tokenIDs="t8">er</lemma>
+      <lemma ID="l9" tokenIDs="t9">.</lemma>
+    </lemmas>
+    <POStags tagset="STTS"><tag tokenIDs="t1">NE</tag><tag tokenIDs="t2">VVFIN</tag><tag tokenIDs="t3">ART</tag><tag tokenIDs="t4">NE</tag><tag tokenIDs="t5">$.</tag><tag tokenIDs="t6">PPER</tag><tag tokenIDs="t7">VVFIN</tag><tag tokenIDs="t8">PPER</tag><tag tokenIDs="t9">$.</tag></POStags>
+    <topologicalFields tagset="DANIELDK">
+   <field tokenIDs="t1">VF</field>
+   <field tokenIDs="t2">LK</field>
+   <field tokenIDs="t3">MF</field>
+   <field tokenIDs="t4">MF</field>
+   <field tokenIDs="t5">UNK</field>
+   <field tokenIDs="t6">VF</field>
+   <field tokenIDs="t7">LK</field>
+   <field tokenIDs="t8">MF</field>
+   <field tokenIDs="t9">UNK</field>
+</topologicalFields>
+  </TextCorpus>
+</D-Spin>

--- a/src/test/resources/data_v5/tc-topo/tcf-after.xml
+++ b/src/test/resources/data_v5/tc-topo/tcf-after.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml-model href="http://de.clarin.eu/images/weblicht-tutorials/resources/tcf-04/schemas/latest/d-spin_0_4.rnc" type="application/relax-ng-compact-syntax"?>
+<D-Spin xmlns="http://www.dspin.de/data" version="0.4">
+ <MetaData xmlns="http://www.dspin.de/data/metadata">
+  <source>IMS, Uni Stuttgart</source>
+ </MetaData>
+ <TextCorpus xmlns="http://www.dspin.de/data/textcorpus" lang="de">
+  <text>Peter aß eine Käsepizza. Sie schmeckte ihm.</text>
+  <tokens>
+   <token ID="t1">Peter</token>
+   <token ID="t2">aß</token>
+   <token ID="t3">eine</token>
+   <token ID="t4">Käsepizza</token>
+   <token ID="t5">.</token>
+   <token ID="t6">Sie</token>
+   <token ID="t7">schmeckte</token>
+   <token ID="t8">ihm</token>
+   <token ID="t9">.</token>
+  </tokens>
+  <sentences>
+   <sentence ID="s1" tokenIDs="t1 t2 t3 t4 t5"/>
+   <sentence ID="s2" tokenIDs="t6 t7 t8 t9"/>
+  </sentences>
+  <lemmas>
+   <lemma ID="l1" tokenIDs="t1">Peter</lemma>
+   <lemma ID="l2" tokenIDs="t2">essen</lemma>
+   <lemma ID="l3" tokenIDs="t3">ein</lemma>
+   <lemma ID="l4" tokenIDs="t4">Käsepizza</lemma>
+   <lemma ID="l5" tokenIDs="t5">.</lemma>
+   <lemma ID="l6" tokenIDs="t6">sie</lemma>
+   <lemma ID="l7" tokenIDs="t7">schmecken</lemma>
+   <lemma ID="l8" tokenIDs="t8">er</lemma>
+   <lemma ID="l9" tokenIDs="t9">.</lemma>
+ </lemmas>
+ <POStags tagset="STTS">
+   <tag tokenIDs="t1">NE</tag>
+   <tag tokenIDs="t2">VVFIN</tag>
+   <tag tokenIDs="t3">ART</tag>
+   <tag tokenIDs="t4">NE</tag>
+   <tag tokenIDs="t5">$.</tag>
+   <tag tokenIDs="t6">PPER</tag>
+   <tag tokenIDs="t7">VVFIN</tag>
+   <tag tokenIDs="t8">PPER</tag>
+   <tag tokenIDs="t9">$.</tag>
+  </POStags>
+<topologicalFields tagset="DANIELDK">
+   <field tokenIDs="t1">VF</field>
+   <field tokenIDs="t2">LK</field>
+   <field tokenIDs="t3">MF</field>
+   <field tokenIDs="t4">MF</field>
+   <field tokenIDs="t5">UNK</field>
+   <field tokenIDs="t6">VF</field>
+   <field tokenIDs="t7">LK</field>
+   <field tokenIDs="t8">MF</field>
+   <field tokenIDs="t9">UNK</field>
+</topologicalFields>
+ </TextCorpus>
+</D-Spin>

--- a/src/test/resources/data_v5/tc-topo/tcf-before.xml
+++ b/src/test/resources/data_v5/tc-topo/tcf-before.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml-model href="http://de.clarin.eu/images/weblicht-tutorials/resources/tcf-04/schemas/latest/d-spin_0_4.rnc" type="application/relax-ng-compact-syntax"?>
+<D-Spin xmlns="http://www.dspin.de/data" version="0.4">
+ <MetaData xmlns="http://www.dspin.de/data/metadata">
+  <source>IMS, Uni Stuttgart</source>
+ </MetaData>
+ <TextCorpus xmlns="http://www.dspin.de/data/textcorpus" lang="de">
+  <text>Peter aß eine Käsepizza. Sie schmeckte ihm.</text>
+  <tokens>
+   <token ID="t1">Peter</token>
+   <token ID="t2">aß</token>
+   <token ID="t3">eine</token>
+   <token ID="t4">Käsepizza</token>
+   <token ID="t5">.</token>
+   <token ID="t6">Sie</token>
+   <token ID="t7">schmeckte</token>
+   <token ID="t8">ihm</token>
+   <token ID="t9">.</token>
+  </tokens>
+  <sentences>
+   <sentence ID="s1" tokenIDs="t1 t2 t3 t4 t5"/>
+   <sentence ID="s2" tokenIDs="t6 t7 t8 t9"/>
+  </sentences>
+  <lemmas>
+   <lemma ID="l1" tokenIDs="t1">Peter</lemma>
+   <lemma ID="l2" tokenIDs="t2">essen</lemma>
+   <lemma ID="l3" tokenIDs="t3">ein</lemma>
+   <lemma ID="l4" tokenIDs="t4">Käsepizza</lemma>
+   <lemma ID="l5" tokenIDs="t5">.</lemma>
+   <lemma ID="l6" tokenIDs="t6">sie</lemma>
+   <lemma ID="l7" tokenIDs="t7">schmecken</lemma>
+   <lemma ID="l8" tokenIDs="t8">er</lemma>
+   <lemma ID="l9" tokenIDs="t9">.</lemma>
+ </lemmas> 
+ <POStags tagset="STTS">
+   <tag tokenIDs="t1">NE</tag>
+   <tag tokenIDs="t2">VVFIN</tag>
+   <tag tokenIDs="t3">ART</tag>
+   <tag tokenIDs="t4">NE</tag>
+   <tag tokenIDs="t5">$.</tag>
+   <tag tokenIDs="t6">PPER</tag>
+   <tag tokenIDs="t7">VVFIN</tag>
+   <tag tokenIDs="t8">PPER</tag>
+   <tag tokenIDs="t9">$.</tag>
+ </POStags>
+ </TextCorpus>
+</D-Spin>


### PR DESCRIPTION
This pull request contains the changes that allow the use of the new topological field layer that was added to the new TCF format. The topological field layer looks like this:

```xml
<topologicalFields tagset="DANIELDK">
   <field tokenIDs="t1">VF</field>
   <field tokenIDs="t2">LK</field>
   <field tokenIDs="t3">MF</field>
   <field tokenIDs="t4">MF</field>
   <field tokenIDs="t5">UNK</field>
   <field tokenIDs="t6">VF</field>
   <field tokenIDs="t7">LK</field>
   <field tokenIDs="t8">MF</field>
   <field tokenIDs="t9">UNK</field>
</topologicalFields>
```

Each token in a sentence is associated with a topological field. Examples are
VF: Vorfeld
LK: linke Klammer
MF: Mittelfeld
UNK: unknown
To create a topologicalFields layer a tagset has to be specified. 

This PR contains 

- the interfaces: TopologicalField.java and TopologicalFieldsLayer.java and a test for the new layer: test_v5/TopologicalFieldsTest.java 
- the classes: TopologicalFieldStored.java and TopologicalFieldsLayerStored.java and a test for creating the new layer after reading other layers from TCF: test_v5/TextCorpusTopologicalFieldsTest.java 
- changes in the following files to bind the new layer: TextCorpus.java , TextCorpusLayerTag.java, TextCorpusStored.java, TextCorpusLayersConnector.java
- XML files with and without the new layer for the tests: data_v5/tc-topo/layer-input.xml, data_v5/tc-topo/output-expected.xml , data_v5/tc-topo/tcf-before.xml, tc-topo/tcf-after.xml
